### PR TITLE
Omit missing objects from HeapObject#references

### DIFF
--- a/lib/sheap.rb
+++ b/lib/sheap.rb
@@ -114,7 +114,7 @@ class Sheap
     def references
       referenced_addrs.map do |addr|
         @heap.at(addr)
-      end
+      end.compact
     end
 
     def inverse_references


### PR DESCRIPTION
I'm not sure of _the best_ way to do this, but while analyzing some heap dumps I saw that some objects had references to addresses that weren't in the heap dump. 

This would break `find_path` because it ran into an unexpected `nil` object sometimes. I also experimented with compacting just in `find_path` but I figured it might be better to get closer to the places where references are converted from addresses to HeapObjects.